### PR TITLE
fix マーケットからのインストール時メディアが投稿できない問題を修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,5 +9,6 @@
     "id": "logseq-plugin-for-misskey",
     "title": "Misskey Plugin",
     "icon": "icon_ki.png"
-  }
+  },
+  "effect": true
 }


### PR DESCRIPTION
当拡張機能はファイルのアップロード時に`file`プロトコルを使用しアップロードするファイルを読み込んでいる。しかしマーケットプレイスからのインストールの場合、`manifest.json`もしくは`package.json`に`effect: true`を設定していない限りロード時に`lsp`プロトコルで読み込まれるため`file`プロトコルが使えないというバグがあった。このpull requestはそれを修正したもの。

※ コメントを読む感じこのオプションはマーケットプレイスの`manifest.json`にしか存在してはいけない雰囲気があるしもでレーションの関係からもそっちの方がいいと思うのでそのうち使えなくなるかも